### PR TITLE
use version numbers instead of release on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false


### PR DESCRIPTION
release will change, but since the package supports 0.5 in
REQUIRE it should continue to be tested