### PR TITLE
Adds an id to the observable

### DIFF
--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -1,6 +1,6 @@
 module Observables
 
-export Observable, on, off, onany, connect!
+export Observable, on, off, onany, connect!, obsid
 
 if isdefined(Base, :Iterators) && isdefined(Base.Iterators, :filter)
     import Base.Iterators.filter
@@ -12,11 +12,19 @@ end
 Like a `Ref` but updates can be watched by adding a handler using `on`.
 """
 type Observable{T}
+    id::String
     val::T
     listeners::Vector
 end
-(::Type{Observable{T}}){T}(val) = Observable{T}(val, Any[])
+(::Type{Observable{T}}){T}(val) = Observable{T}(newid(), val, Any[])
 Observable{T}(val::T) = Observable{T}(val)
+
+let count=0
+    global newid
+    function newid(prefix="ob_")
+        string(prefix, lpad(count += 1, 2, "0"))
+    end
+end
 
 """
     on(f, o::Observable)
@@ -77,6 +85,8 @@ Base.getindex(o::Observable) = o.val
 
 _val(o::Observable) = o[]
 _val(x) = x
+
+obsid(o::Observable) = o.id
 
 """
     onany(f, args...)

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -129,6 +129,8 @@ function Base.map(f, o::Observable, os...; init=f(o[], map(_val, os)...))
     map!(f, Observable(init), o, os...)
 end
 
+Base.eltype{T}(::Observable{T}) = T
+
 # TODO: overload broadcast on v0.6
 
 end # module


### PR DESCRIPTION
This is used in a forthcoming PR to WebIO to enable syncing observables across Widgets

n.b. eltype(obs) change is also in #7