### PR TITLE
add precompilation

### DIFF
--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 module Observables
 
 export Observable, on, off, onany, connect!, obsid


### PR DESCRIPTION
Same as for JSExpr: as it's a dependency of precompilable packages, it should also be precompilable.