### PR TITLE
async_latest

### DIFF
--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -1,6 +1,6 @@
 module Observables
 
-export Observable, on, off, onany, connect!, obsid
+export Observable, on, off, onany, connect!, obsid, async_latest
 
 if isdefined(Base, :Iterators) && isdefined(Base.Iterators, :filter)
     import Base.Iterators.filter
@@ -149,6 +149,72 @@ function Base.map(f, o::Observable, os...; init=f(o[], map(_val, os)...))
 end
 
 Base.eltype{T}(::Observable{T}) = T
+
+"""
+`async_latest(o::Observable, n=1)`
+
+Returns an `Observable` which drops all but
+the last `n` updates to `o` if processing the updates
+takes longer than the interval between updates.
+
+This is useful if you want to pass the updates from,
+say, a slider to a plotting function that takes a while to
+compute. The plot will directly compute the last frame
+skipping the intermediate ones.
+
+# Example:
+```
+o = Observable(0)
+function compute_something(x)
+    for i=1:10^8 rand() end # simulate something expensive
+    println("updated with \$x")
+end
+o_latest = async_latest(o, 1)
+on(compute_something, o_latest) # compute something on the latest update
+
+for i=1:5
+    o[] = i
+end
+```
+"""
+function async_latest(input::Observable{T}, n=1) where T
+    buffer = T[]
+    cond = Condition()
+    lck  = ReentrantLock() # advisory lock for access to buffer
+    output = Observable{T}(input[]) # output
+
+    @async while true
+        while true # while !isempty(buffer) but with a lock
+            # transact a pop
+            lock(lck)
+            if isempty(buffer)
+                unlock(lck)
+                break
+            end
+            upd = pop!(buffer)
+            unlock(lck)
+
+            output[] = upd
+        end
+        wait(cond)
+    end
+
+    on(input) do val
+        lock(lck)
+        if length(buffer) < n
+            push!(buffer, val)
+        else
+            while length(buffer) >= n
+                pop!(buffer)
+            end
+            unshift!(buffer, val)
+        end
+        unlock(lck)
+        notify(cond)
+    end
+
+    output
+end
 
 # TODO: overload broadcast on v0.6
 


### PR DESCRIPTION
A function that transforms an Observable to another that updates asynchronously as and when there is a chance to do so, discarding all but the last `n` updates.

```julia
o = Observable(0)
function compute_something(x)
    for i=1:10^8 rand() end # simulate something expensive
    println("updated with $x")
end
o_latest = async_latest(o, 1)
on(compute_something, o_latest) # compute something on the latest update

for i=1:5
    o[] = i # this is asynchronous
end

## Output
updated with 5 # only the last one got fired.
```

Somehow Julia takes offence if I use an anonymous function on `o_latest`
```julia
o = Observable(0)
o_latest = async_latest(o, 1)
on(o_latest) do x
    for i=1:10^8 rand() end # simulate something expensive
    println("updated with $x")
end

for i=1:5
    o[] = i
end

## Error:
ERROR (unhandled task failure): MethodError: no method matching (::##3#4)(::Int64)
The applicable method may be too new: running in world age 21870, while current world is 21871.
Closest candidates are:                
  #3(::Any) at REPL[9]:2 (method too new to be called from this world context.)

```