### PR TITLE
fix map for type unstable functions

### DIFF
--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -147,7 +147,7 @@ dispatch reasons. `args` may contain any number of `Observable` ojects.
 All other ojects in `args` are passed as-is.
 """
 function Base.map(f, o::Observable, os...; init=f(o[], map(_val, os)...))
-    map!(f, Observable(init), o, os...)
+    map!(f, Observable{Any}(init), o, os...)
 end
 
 Base.eltype(::Observable{T}) where {T} = T


### PR DESCRIPTION
Otherwise, `map` errors every time `f` is type unstable. I think we shouldn't rely on inference to determine the result, so I guess the correct thing is to use a `Observable` of type `Any`.