### PR TITLE
catch + print errors manually

### DIFF
--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -76,7 +76,16 @@ function Base.setindex!(o::Observable, val; notify=x->true)
     o.val = val
     for f in listeners(o)
         if notify(f)
-            f(val)
+            try
+                f(val)
+            catch e
+                # As weird as it is, Julia does seem to have problems with errors
+                # encountered in f(val) - it might stack overflow or just silently freeze
+                # the try catch and manual error display seems to solve this
+                Base.showerror(stderr, e)
+                Base.show_backtrace(stderr, catch_backtrace())
+                rethrow(e)
+            end
         end
     end
 end


### PR DESCRIPTION
Julia does seem to have problems with errors `setindex(obs, val)` - it might stack overflow or just silently freeze. A try catch and manual error display seems to solve this