### PR TITLE
do not require changed value to update throttled observable

### DIFF
--- a/src/time.jl
+++ b/src/time.jl
@@ -7,12 +7,13 @@ the last update of the `input` signal during each `dt` second time window.
 function throttle(dt, obs::AbstractObservable{T}) where {T}
     throttled = Observable{T}(obs[])
     updatable = Observable(true)
-    set_throttled(val) = (throttled[] != val) && (throttled[] = val; updatable[] = false)
+    pending = Ref(false)
+    update!() = (throttled[] = obs[]; pending[] = false; updatable[] = false)
     on(updatable) do val
-        val ? set_throttled(obs[]) : Timer(t -> updatable[] = true, dt)
+        val ? pending[] && update!() : Timer(t -> updatable[] = true, dt)
     end
     on(obs) do val
-        updatable[] && set_throttled(val)
+        updatable[] ? update!() : (pending[] = true)
     end
     throttled
 end


### PR DESCRIPTION
To fix https://github.com/JuliaGizmos/Interact.jl/issues/274. A throttled `Observable` should get "set" after the delay if the input observable was triggered, even if the underlying value has not changed (meaning it will be set to the same value).