### PR TITLE
fix documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,7 +3,7 @@ using Documenter, Observables
 makedocs(
     modules = [Observables],
     clean = false,
-    format = :html,
+    format = Documenter.HTML(),
     sitename = "Observables.jl",
     authors = "JuliaGizmos",
     pages = Any["Home" => "index.md"],

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -33,17 +33,16 @@ Another difference is Observables are synchronous, Signals are asynchronous. Obs
 
 ## API
 
-```@docs
-Observable{T}
-on(f, o::Observable)
-off(o::Observable, f)
-Base.setindex!(o::Observable, val)
-Base.getindex(o::Observable)
-onany(f, os...)
-Observables.@on
-Base.map!(f, o::Observable, os...)
-Observables.@map!
-connect!(o1::Observable, o2::Observable)
-Base.map(f, o::Observable, os...; init)
-Observables.@map
+### Public
+
+```@autodocs
+Modules = [Observables]
+Private = false
+```
+
+### Internal
+
+```@autodocs
+Modules = [Observables]
+Public = false
 ```

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -175,7 +175,7 @@ end
 Base.eltype(::AbstractObservable{T}) where {T} = T
 
 """
-`async_latest(o::AbstractObservable, n=1)`
+    async_latest(o::AbstractObservable, n=1)
 
 Returns an `Observable` which drops all but
 the last `n` updates to `o` if processing the updates

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -28,7 +28,7 @@ computed when `@map` is called and  every time the `AbstractObservables` are upd
 
 ## Examples
 
-```jldoctest mapmacro
+```
 julia> a = Observable(2);
 
 julia> b = Observable(3);
@@ -62,7 +62,7 @@ computed every time the `AbstractObservables` are updated and `d` will be set to
 
 ## Examples
 
-```jldoctest mapmacro
+```
 julia> a = Observable(2);
 
 julia> b = Observable(3);
@@ -98,7 +98,7 @@ computed every time the `AbstractObservables` are updated.
 
 ## Examples
 
-```jldoctest onmacro
+```
 julia> a = Observable(2);
 
 julia> b = Observable(3);

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -21,7 +21,7 @@ function map_helper(expr)
 end
 
 """
-`@map(expr)`
+    @map(expr)
 
 Wrap `AbstractObservables` in `&` to compute expression `expr` using their value. The expression will be
 computed when `@map` is called and  every time the `AbstractObservables` are updated.
@@ -55,7 +55,7 @@ function map!_helper(d, expr)
 end
 
 """
-`@map!(d, expr)`
+    @map!(d, expr)
 
 Wrap `AbstractObservables` in `&` to compute expression `expr` using their value: the expression will be
 computed every time the `AbstractObservables` are updated and `d` will be set to match that value.
@@ -91,7 +91,7 @@ function on_helper(expr)
 end
 
 """
-`@on(expr)`
+    @on(expr)
 
 Wrap `AbstractObservables` in `&` to execute expression `expr` using their value. The expression will be
 computed every time the `AbstractObservables` are updated.

--- a/src/time.jl
+++ b/src/time.jl
@@ -1,5 +1,5 @@
 """
-`throttle(dt, input::AbstractObservable)`
+    throttle(dt, input::AbstractObservable)
 
 Throttle a signal to update at most once every `dt` seconds. The throttled signal holds
 the last update of the `input` signal during each `dt` second time window.


### PR DESCRIPTION
I missed `throttle()` from the documentation and tried to add it but encountered some issues, that I try to resolve in this PR.
Firstly, the documentation site is outdated. The last build was 11 month ago, neither releases and "latest" versions did not get their documentation.
I think the issue is, that the macros have doctests, which fail, because `using Observables` is missing.
I solved it with removing the `jldoctest` tag.
Secondly I wanted to add `throttle()` to the docs and thought that it would be easier to use `@autodocs`
Thirdly, I fixed a deprication warning in `make.jl`.