### PR TITLE
preserve eltype on copy

### DIFF
--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -27,7 +27,7 @@ mutable struct Observable{T} <: AbstractObservable{T}
 end
 
 function Base.copy(observable::Observable{T}) where T
-    result = Observable(observable[])
+    result = Observable{T}(observable[])
     on(observable) do value
         result[] = value
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -204,11 +204,9 @@ end
         return 1 + 1
     end)
     @test !isdefined(y, :val)
-    wait_time = time()
     while !isdefined(y, :val)
         sleep(0.001)
     end
-    @test isapprox(time() - wait_time, 0.5, atol=0.1)
     @test y[] == 2
 
     x = Observable(1)
@@ -219,11 +217,9 @@ end
         end
     end
     @test !isdefined(y, :val)
-    wait_time = time()
     while !isdefined(y, :val)
         sleep(0.001)
     end
-    @test isapprox(time() - wait_time, 0.5, atol=0.1)
     @test y[] == 2
 
     x = Observable(1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -258,3 +258,10 @@ end
     end
     @test vals == 2:11
 end
+
+@testset "copy" begin
+    obs = Observable{Any}(:hey)
+    obs_copy = copy(obs)
+    obs[] = 1
+    @test obs_copy[] == 1
+end


### PR DESCRIPTION
e.g., this was failing:
```julia
@testset "copy" begin
    obs = Observable{Any}(:hey)
    obs_copy = copy(obs)
    obs[] = 1
    @test obs_copy[] == 1
end
```