### PR TITLE
Introduce self-deregistering closures for on / onany

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,7 +7,7 @@ using Observables
 
 observable = Observable(0)
 
-h = on(observable) do val
+obs_func = on(observable) do val
     println("Got an update: ", val)
 end
 
@@ -22,7 +22,24 @@ observable[]
 To remove a handler use `off` with the return value of `on`:
 
 ```@repl manual
-off(observable, h)
+off(obs_func)
+```
+
+### Weak Connections
+
+If you use `on` with `weak = true`, the connection will be removed when
+the return value of `on` is garbage collected.
+This can make it easier to clean up connections that are not used anymore.
+
+
+```julia
+obs_func = on(observable, weak = true) do val
+    println("Got an update: ", val)
+end
+# as long as obs_func is reachable the connection will stay
+
+obs_func = nothing
+# now garbage collection can at any time clear the connection
 ```
 
 ### Async operations

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -114,8 +114,8 @@ mutable struct ObserverFunction <: Function
         # storing it in its listeners once the ObserverFunction is garbage collected.
         # This should free all resources associated with f unless there
         # is another reference to it somewhere else.
-        finalizer(obsfunc) do obsfunc
-            if obsfunc.weak
+        if obsfunc.weak
+            finalizer(obsfunc) do obsfunc
                 off(obsfunc)
             end
         end

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -126,12 +126,19 @@ end
 
 
 """
-    on(f, observable::AbstractObservable)
+    on(f, observable::AbstractObservable; weak = false)
 
 Adds function `f` as listener to `observable`. Whenever `observable`'s value
 is set via `observable[] = val` `f` is called with `val`.
 
-Returns `true` if `f` could be removed, otherwise `false`.
+Returns an `ObserverFunction` that wraps `f` and `observable` and allows to
+disconnect easily by calling `off(observerfunction)` instead of `off(f, observable)`.
+
+If `weak = true` is set, the new connection will be removed as soon as the returned `ObserverFunction`
+is not referenced anywhere and is garbage collected. This is useful if some parent object
+makes connections to outside observables and stores the resulting `ObserverFunction` instances.
+Then, once that parent object is garbage collected, the weak
+observable connections are removed automatically.
 """
 function on(f, observable::AbstractObservable; weak = false)
     push!(listeners(observable), f)

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -130,6 +130,8 @@ end
 
 Adds function `f` as listener to `observable`. Whenever `observable`'s value
 is set via `observable[] = val` `f` is called with `val`.
+
+Returns `true` if `f` could be removed, otherwise `false`.
 """
 function on(f, observable::AbstractObservable; weak = false)
     push!(listeners(observable), f)
@@ -147,6 +149,8 @@ end
     off(observable::AbstractObservable, f)
 
 Removes `f` from listeners of `observable`.
+
+Returns `true` if `f` could be removed, otherwise `false`.
 """
 function off(observable::AbstractObservable, f)
     callbacks = listeners(observable)
@@ -156,10 +160,10 @@ function off(observable::AbstractObservable, f)
             for g in removehandler_callbacks
                 g(observable, f)
             end
-            return
+            return true
         end
     end
-    throw(KeyError(f))
+    return false
 end
 
 

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -103,7 +103,7 @@ It can still be useful because it is easier to call `off(obsfunc)` instead of `o
 to release the connection later.
 """
 mutable struct ObserverFunction <: Function
-    f::Function
+    f
     observable::AbstractObservable
     weak::Bool
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,6 +44,30 @@ end
     @test r2[] == 4
 end
 
+@testset "weak connections" begin
+    a = Observable(1)
+
+    function barrier()
+        b = Ref(1)
+        sdf = on(a) do a
+            b[] += 1
+        end
+
+        a[] = 2
+        @test b[] == 2
+
+        nothing
+    end
+
+    GC.enable(false)
+    barrier()
+    @test length(Observables.listeners(a)) == 1
+
+    GC.enable(true)
+    GC.gc()
+    @test isempty(Observables.listeners(a))
+end
+
 @testset "macros" begin
     a = Observable(2)
     b = Observable(3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,14 +64,14 @@ end
     function create_a_dangling_listener()
         t = ToFinalize(1)
 
-        sdf = on(a) do a
+        obsfunc = on(a; weak = true) do a
             t.val += 1
         end
 
         a[] = 2
         @test t.val == 2
 
-        # sdf falls out of scope here and should deregister the closure
+        # obsfunc falls out of scope here and should deregister the closure
         # when it gets garbage collected, which should in turn free t
         nothing
     end
@@ -83,7 +83,7 @@ end
 
     GC.enable(true)
     GC.gc()
-    # somehow this needs a double sweep, maybe first sdf, then ToFinalize?
+    # somehow this needs a double sweep, maybe first obsfunc, then ToFinalize?
     GC.gc()
     @test isempty(Observables.listeners(a))
     @test memory_cleared[] == true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,6 +44,27 @@ end
     @test r2[] == 4
 end
 
+@testset "disconnect observerfuncs" begin
+    
+    x = Observable(1)
+    y = Observable(2)
+    z = Observable(3)
+
+    of1 = on(x) do x
+        println(x)
+    end
+
+    of2_3 = onany(y, z) do y, z
+        println(y, z)
+    end
+
+    off(of1)
+    off.(of2_3)
+    for obs in (x, y, z)
+        @test isempty(obs.listeners)
+    end
+end
+
 # this struct is just supposed to show that a value in memory was released
 mutable struct ToFinalize
     val

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,9 +13,9 @@ using Test
     end
     r[] = 2
 
-    off(r, f)
+    @test off(r, f)
     @test !(f in r.listeners)
-    @test_throws KeyError off(r, f)
+    @test off(r, f) == false
     r[] = 3 # shouldn't call test
 end
 


### PR DESCRIPTION
We still have the problem that it's hard to keep track of the connections we make with Observables and to clean them up after use. This PR seeks to help while staying close enough to the previous API, that it hopefully doesn't break too much code using Observables.

The main change is that `on` returns a new type `ObserverFunction`. This wraps the closure `Function` which is normally returned by `on`. It stores the function, the observable that is being listened to, and a `weak` flag. If the `weak` flag is set via `on(..., weak = true)`, the `ObserverFunction` will call `off(observable, closure)` when finalized.

This allows for some easy housekeeping. Imagine some large plotting object that creates multiple connections via `on`. We just have to `push!` all weak `ObserverFunction`s into one big vector, and if our plot object goes out of scope, so will that vector and all the connections we made will be released.

The `weak` flag is set to `false` by default, which means that the behavior doesn't change from what we have now.

Even with `weak = false`, this PR can make it a bit easier to clean up Observables, as the `ObserverFunctions` carry both the closure and related Observable, and it's therefore easier to call `off(observerfunc)` without having to find both of these parts first.

I see almost no code storing the result of `on` in the wild right now, which would be necessary to do housekeeping (which is not being done). It would therefore be easy with this PR to improve code by storing the result and calling `off` on it at an appropriate time, or making the whole thing `weak` and let scoping handle it. If preexisting code is storing the result of `on`, then the receiving structure is probably typed `Function`, and as I've made `ObserverFunction <: Function` this should also not be breaking.

CI is currently failing because of some problem with ObservablePairs. I have never used this and cannot understand from the code what they are supposed to do. Neither are they documented. So I assume they are not very important.