### PR TITLE
Fix `connect!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Observables"
 uuid = "510215fc-4207-5dde-b226-833fc4488ee2"
-version = "0.3.3"
+version = "0.4.0"
 
 [compat]
 julia = "1"

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -347,9 +347,11 @@ end
 """
     connect!(o1::AbstractObservable, o2::AbstractObservable)
 
-Forwards all updates from `o2` to `o1`
+Forwards all updates from `o2` to `o1`.
+
+See also [`Observables.ObservablePair`](@ref).
 """
-connect!(o1::AbstractObservable, o2::AbstractObservable) = map!(identity, o2, o1)
+connect!(o1::AbstractObservable, o2::AbstractObservable) = map!(identity, o1, o2)
 
 """
     map(f, observable::AbstractObservable, args...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -195,6 +195,13 @@ end
     @test cnt[] == 3
 end
 
+@testset "connect!" begin
+    a, b = Observable(""), Observable("")
+    connect!(a, b)
+    b[] = "Hi!"
+    @test a[] == "Hi!"
+end
+
 @testset "throttle" begin
     obs = Observable(1)
     throttled = throttle(2, obs)


### PR DESCRIPTION
`connect!` did the opposite of what was described in the docstring.
The docstring is more consistent with the convention of the modified
argument being first, so we go with the docstring and change the code.

While technically this is a bugfix, it could trigger StackOverFlow
errors, so let's call this a breaking change.