### PR TITLE
Let `map` store ObserverFuncs & add precompile

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,6 +51,9 @@ end
     @test r2[] == 3
     r1[] = 3
     @test r2[] == 4
+
+    # Make sure `precompile` doesn't error
+    precompile(r1)
 end
 
 @testset "disconnect observerfuncs" begin


### PR DESCRIPTION
This addresses a comment made in
https://github.com/JuliaGizmos/Observables.jl/pull/48#issuecomment-699608226
by implementing storage for the ObserverFunctions
added by `map`.

This also adds optional precompilation support for observables,
precompiling the methods based on the `T` in `Observable{T}`.
Since `on` doesn't call the function right away, I don't think there's a way to precompile
them automatically (there would be, if `on` immediately called the callback, but of course
that has issues too). So it's a step you have to perform manually.