### PR TITLE
Always use invokelatest

### DIFF
--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -17,9 +17,6 @@ const removehandler_callbacks = []
 
 abstract type AbstractObservable{T} end
 
-# Internal function that doesn't need invokelatest!
-abstract type InternalFunction <: Function end
-
 function observe(::S) where {S<:AbstractObservable}
     error("observe not defined for AbstractObservable $S")
 end
@@ -88,11 +85,7 @@ Update all listeners of `observable`.
 function Base.notify(observable::AbstractObservable)
     val = observable[]
     for f in listeners(observable)
-        if f isa InternalFunction
-            f(val)
-        else
-            Base.invokelatest(f, val)
-        end
+        Base.invokelatest(f, val)
     end
     return
 end
@@ -333,7 +326,7 @@ obsid(observable::AbstractObservable) = obsid(observe(observable))
 listeners(observable::Observable) = observable.listeners
 listeners(observable::AbstractObservable) = listeners(observe(observable))
 
-struct OnUpdate{F, Args} <: InternalFunction
+struct OnUpdate{F, Args} <: Function
     f::F
     args::Args
 end
@@ -370,7 +363,7 @@ end
     obsfuncs
 end
 
-struct MapUpdater{F, T} <: InternalFunction
+struct MapUpdater{F, T} <: Function
     f::F
     observable::Observable{T}
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -145,6 +145,20 @@ end
     @test finalized_flag[] == true
 end
 
+@testset "world age" begin
+    # issue #50
+    obs = Observable(0)
+    t = @task for n=1:10
+        obs[] = n
+        sleep(0.1)
+    end
+    schedule(t)
+    sleep(0.1)
+    map(x->2x, obs)
+    sleep(0.2)
+    @test !istaskfailed(t)
+end
+
 @testset "macros" begin
     a = Observable(2)
     b = Observable(3)


### PR DESCRIPTION
`map` was not safe in conjunction with `@async`. Since even one of the
examples in the manual used it that way, let's just get rid of the
special dispatch for `InternalFunction`.

Fixes #50

@SimonDanisch, I know this one might have made you sad. Is there a place where this matters more than others?

Benchmarks:
```julia
julia> f1(x) = sin(x)
f1 (generic function with 1 method)

julia> f2(x) = Base.invokelatest(sin, x)
f2 (generic function with 1 method)

julia> using BenchmarkTools

julia> @btime f1(x) setup=(x=rand());
  3.681 ns (0 allocations: 0 bytes)

julia> @btime f2(x) setup=(x=rand());
  55.407 ns (3 allocations: 48 bytes)

julia> f3(x) = sin(x[])
f3 (generic function with 1 method)

julia> @btime f3(x) setup=(x=Ref{Any}(rand()));
  18.016 ns (1 allocation: 16 bytes)
```
So it's about 3x the cost of a single runtime dispatch (which due to poor inferrability, Makie has a lot of).