### PR TITLE
modify MapUpdater to hold AbstractObservables instead of Observables

### DIFF
--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -365,7 +365,7 @@ end
 
 struct MapUpdater{F, T} <: Function
     f::F
-    observable::Observable{T}
+    observable::AbstractObservable{T}
 end
 
 function (mu::MapUpdater)(args...)


### PR DESCRIPTION
This is the PR to #72

Currently, Observables throws an error when trying to `map!(any, r, o)` where o is a normal Observable and r is of a different observable type `R{T} <: AbstractObservable{T}`.

As `map!()`, `map()` and `connect!()` all support `AbstractObservables`, this is probably the only place, that needs to be adapted.