### PR TITLE
add ChangeObservable

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -28,7 +28,6 @@ off(obs_func)
 
 If you wish to only listen to changes, a `ChangeObservable` can be used
 
-
 ```@repl manual
 using Observables
 
@@ -44,6 +43,24 @@ change_obs[] = 43 # the listener will print
 ```
 
 A `ChangeObservable` is backed by two `Observables` and stores two sets of values.
+
+Or to selectively do either, `observe_changes` can be used
+
+```@repl manual
+observable = Observable(0)
+
+obs_change = observe_changes(observable);
+
+obs_func = on(observable) do val
+    println("Got an assignment: ", val)
+end
+
+obs_change_func = on(obs_change) do val
+    println("The value changed: ", val)
+end
+
+observable[] = 42
+```
 
 ### Weak Connections
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,11 +10,11 @@ observable = Observable(0)
 observable[]
 ```
 
-But unlike `Ref`s,  but you can listen for changes:
+But unlike `Ref`s,  but you can listen for assignments:
 
 ```@repl manual
 obs_func = on(observable) do val
-    println("Got an update: ", val)
+    println("Got an assignment: ", val)
 end
 
 observable[] = 42
@@ -25,6 +25,25 @@ To remove a handler use `off` with the return value of `on`:
 ```@repl manual
 off(obs_func)
 ```
+
+If you wish to only listen to changes, a `ChangeObservable` can be used
+
+
+```@repl manual
+using Observables
+
+change_obs = ChangeObservable(0)
+
+obs_func = on(change_obs) do val
+    println("The value changed: ", val)
+end
+
+change_obs[] = 42 # the listener will print
+change_obs[] = 42 # no print
+change_obs[] = 43 # the listener will print
+```
+
+A `ChangeObservable` is backed by two `Observables` and stores two sets of values.
 
 ### Weak Connections
 

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -1,6 +1,7 @@
 module Observables
 
 export Observable, on, off, onany, connect!, obsid, observe_changes, async_latest, throttle
+export ChangeObservable, AbstractObservable
 
 import Base.Iterators.filter
 
@@ -93,7 +94,7 @@ end
 function Base.show(io::IO, x::Observable{T}) where T
     println(io, "Observable{$T} with $(length(x.listeners)) listeners. Value:")
     if isdefined(x, :val)
-        show(io, x.val)
+        show(io, x[])
     else
         print(io, "not assigned yet!")
     end
@@ -365,7 +366,7 @@ end
 
 struct MapUpdater{F, T} <: Function
     f::F
-    observable::Observable{T}
+    observable::AbstractObservable{T}
 end
 
 function (mu::MapUpdater)(args...)
@@ -421,7 +422,7 @@ can handle any number type for which `sqrt` is defined.
     return observable
 end
 
-function appendinputs!(observable, obsfuncs)  # latency: separating this from map! allows dropping the specialization on `f`
+function appendinputs!(observable::Observable, obsfuncs)  # latency: separating this from map! allows dropping the specialization on `f`
     if !isdefined(observable, :inputs)
         observable.inputs = obsfuncs
     else
@@ -589,6 +590,7 @@ include("observablepair.jl")
 include("flatten.jl")
 include("time.jl")
 include("macros.jl")
+include("change.jl")
 
 # Look up the source location of `do` block Observable MethodInstances
 function methodlist(@nospecialize(ft::Type))

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -47,6 +47,8 @@ function Base.copy(observable::Observable{T}) where T
     return result
 end
 
+Base.close(obs::Observable) = empty!(obs.listeners)
+
 Observable(val::T) where {T} = Observable{T}(val)
 
 Base.eltype(::AbstractObservable{T}) where {T} = T

--- a/src/change.jl
+++ b/src/change.jl
@@ -1,0 +1,33 @@
+
+"""
+    obs = ChangeObservable(val)
+    obs = ChangeObservable{T}(val)
+
+Like an `Observable`, but only updates watchers when the value changes
+"""
+struct ChangeObservable{T} <: AbstractObservable{T}
+    obs::AbstractObservable{T}
+    change::AbstractObservable{T}
+    function ChangeObservable{T}(x) where {T}
+        obs = Observable{T}(x)
+        change = observe_changes(obs)
+        return new{T}(obs, change)
+    end
+end
+ChangeObservable(val::T) where {T} = ChangeObservable{T}(val)
+
+Base.close(co::ChangeObservable) = empty!(listeners(co.change))
+
+# Functions on the input side that use the value observable
+Base.setindex!(co::ChangeObservable, val) = Base.setindex!(co.obs, val)
+appendinputs!(co::ChangeObservable, obsfuncs) = appendinputs!(co.obs, obsfuncs)
+
+# Functions on the change side that use the change observable
+Base.getindex(co::ChangeObservable) = Base.getindex(co.change)
+to_value(co::ChangeObservable) = to_value(co.change)
+observe(co::ChangeObservable) = observe(co.change)
+listeners(co::ChangeObservable) = listeners(co.change)
+on(@nospecialize(f), co::ChangeObservable; kwargs...) = on(f, co.change; kwargs...)
+off(co::ChangeObservable, @nospecialize(f)) = off(co.change, f)
+off(co::ChangeObservable, f::ObserverFunction) = off(co.change, f)
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -208,6 +208,18 @@ end
     @test values_approx == 2:2:10
 end
 
+@testset "ChangeObservable" begin
+    co = ChangeObservable(0)
+    values = Int[]
+    on(co) do v
+        push!(values, v)
+    end
+    for i in 1:100
+        co[] = floor(Int, i/10)
+    end
+    @test values == 1:10
+end
+
 @testset "async_latest" begin
     o = Observable(0)
     cnt = Ref(0)


### PR DESCRIPTION
`observe_changes` is great, but requires the user to keep track of two observables and use them in the right way.

This introduces a new `ChangeObservable` type that contains both the value and change observable, and is designed to handle assignment and signaling automatically, so the user just has to keep track of one "observable"

