### PR TITLE
api improvements

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         version:
           - '1.6'
-#         - '1.7'
+          - '1.7'
         os:
           - ubuntu-latest
         arch:
@@ -25,19 +25,6 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
-        with:
-          file: lcov.info

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,9 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
-          - '1.5'
-#          - 'nightly'
+          - '1.6'
+#         - '1.7'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/documenter.yml
+++ b/.github/workflows/documenter.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.4'
+          version: '1.7'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "510215fc-4207-5dde-b226-833fc4488ee2"
 version = "0.4.0"
 
 [compat]
-julia = "1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -42,6 +42,54 @@ end
 obs_func = nothing
 # now garbage collection can at any time clear the connection
 ```
+
+### Priority
+
+One can also give the callback a priority, to enable always calling a specific callback before/after others, independent of the order of registration.
+So one can do:
+
+```julia
+obs = Observable(0)
+on(obs; priority=-1) do x
+    println("Hi from first added")
+end
+on(obs) do x
+    println("Hi from second added")
+end
+obs[] = 2
+Hi from second added
+Hi from first added
+```
+Without the priority, the printing order would be the other way around.
+One can also return `Consume(true/false)`, to consume an event and stop any later callback from getting called.
+
+```julia
+obs = Observable(0)
+on(obs) do x
+    if x == 1
+        println("stop calling callbacks after me!")
+        return Consume(true)
+    else
+        println("Do not consume!")
+    end
+end
+on(obs) do x
+    println("I get called")
+end
+obs[] = 2
+Do not consume!
+I get called
+obs[] = 1
+stop calling callbacks after me!
+```
+
+The first one could of course also be written as:
+```julia
+on(obs) do x
+    return Consume(x == 1)
+end
+```
+
 ### How is it different from Reactive.jl?
 
 The main difference is `Signal`s are manipulated mostly by converting one signal to another. For example, with signals, you can construct a changing UI by creating a `Signal` of UI objects and rendering them as the signal changes. On the other hand, you can use an Observable both as an input and an output. You can arbitrarily attach outputs to inputs allowing structuring code in a [signals-and-slots](http://doc.qt.io/qt-4.8/signalsandslots.html) kind of pattern.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -42,55 +42,6 @@ end
 obs_func = nothing
 # now garbage collection can at any time clear the connection
 ```
-
-### Async operations
-
-#### Delay an update
-
-```@repl manual
-x = Observable(1)
-y = map(x) do val
-    @async begin
-        sleep(1.5)
-        return val + 1
-    end
-end
-tstart = time()
-onany(x, y) do xval, yval
-    println("At ", time()-tstart, ", we have x = ", xval, " and y = ", yval)
-end
-sleep(3)
-x[] = 5
-sleep(3)
-```
-
-#### Multiply updates
-
-If you want to fire several events on an update (e.g., for interpolating animations), you can use a channel:
-
-```@repl manual
-x = Observable(1)
-y = map(x) do val
-    Channel() do channel
-        for i in 1:10
-            put!(channel, i + val)
-        end
-    end
-end; on(y) do val
-    println("updated to ", val)
-end; sleep(2)
-```
-
-Similarly, you can construct the Observable from a `Channel`:
-
-```julia
-Observable(Channel() do channel
-    for i in 1:10
-        put!(channel, i + 1)
-    end
-end)
-```
-
 ### How is it different from Reactive.jl?
 
 The main difference is `Signal`s are manipulated mostly by converting one signal to another. For example, with signals, you can construct a changing UI by creating a `Signal` of UI objects and rendering them as the signal changes. On the other hand, you can use an Observable both as an input and an output. You can arbitrarily attach outputs to inputs allowing structuring code in a [signals-and-slots](http://doc.qt.io/qt-4.8/signalsandslots.html) kind of pattern.

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -1,7 +1,7 @@
 module Observables
 
-export Observable, on, off, onany, connect!, obsid, observe_changes, async_latest, throttle
-export Consume, PriorityObservable, ChangeObservable
+export Observable, on, off, onany, connect!, obsid, async_latest, throttle
+export Consume, PriorityObservable, ChangeObservable, ObserverFunction, AbstractObservable
 
 import Base.Iterators.filter
 

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -4,7 +4,6 @@ export Observable, on, off, onany, connect!, obsid, observe_changes, async_lates
 export Consume, PriorityObservable, ChangeObservable
 
 import Base.Iterators.filter
-Base.Experimental.@max_methods 1
 
 # @nospecialize "blocks" codegen but not necessarily inference. This forces inference
 # to drop specific information about an argument.

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -193,6 +193,7 @@ current value is 5
 ```
 
 One can also give the callback a priority, to enable always calling a specific callback before/after others, independent of the order of registration.
+The callback with the highest priority gets called first, the default is zero, and the whole range of Int can be used.
 So one can do:
 
 ```julia

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -48,6 +48,14 @@ mutable struct Observable{T} <: AbstractObservable{T}
     end
 end
 
+function Base.getproperty(obs::Observable, field::Symbol)
+    if field === :id
+        return obsid(obs)
+    else
+        getfield(obs, field)
+    end
+end
+
 ignore_equal_values(@nospecialize(obs))::Bool = obs isa Observable ? obs.ignore_equal_values : false
 
 Observable(val::T; ignore_equal_values::Bool=false) where {T} = Observable{T}(val; ignore_equal_values)

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -454,14 +454,14 @@ Observable{$Int} with 0 listeners. Value:
 3
 ```
 """
-@inline function Base.map(f::F, arg1::AbstractObservable, args...) where F
+@inline function Base.map(f::F, arg1::AbstractObservable, args...; change_observable=false) where F
     # note: the @inline prevents de-specialization due to the splatting
-    map!(f, Observable(f(arg1[], map(to_value, args)...)), arg1, args...; update=false)
+    obs = Observable(f(arg1[], map(to_value, args)...))
+    obs.ignore_equal_values = change_observable
+    map!(f, obs, arg1, args...; update=false)
+    return obs
 end
 
-function observe_changes(obs::AbstractObservable{T}, eq=(==)) where T
-
-end
 
 """
     async_latest(observable::AbstractObservable, n=1)

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -161,7 +161,7 @@ mutable struct ObserverFunction <: Function
 end
 
 """
-    on(f, observable::AbstractObservable; weak = false)::ObserverFunction
+    on(f, observable::AbstractObservable; weak = false, priority=0, update=false)::ObserverFunction
 
 Adds function `f` as listener to `observable`. Whenever `observable`'s value
 is set via `observable[] = val`, `f` is called with `val`.
@@ -191,6 +191,31 @@ julia> on(obs) do val
 julia> obs[] = 5;
 current value is 5
 ```
+
+One can also give the callback a priority, to enable always calling a specific callback before/after others, independent of the order of registration.
+So one can do:
+
+```julia
+julia> obs = Observable(0)
+julia> on(obs; priority=-1) do x
+           println("Hi from first added")
+       end
+julia> on(obs) do x
+           println("Hi from second added")
+       end
+julia> obs[] = 2
+Hi from second added
+Hi from first added
+```
+
+If you set `update=true`, on will call f(obs[]) immediately:
+```julia
+julia> on(Observable(1); update=true) do x
+    println("hi")
+end
+hi
+```
+
 """
 function on(@nospecialize(f), @nospecialize(observable::AbstractObservable); weak::Bool = false, priority::Int = 0, update::Bool = false)::ObserverFunction
     register_callback(observable, priority, f)

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -22,10 +22,6 @@ abstract type AbstractObservable{T} end
 const addhandler_callbacks = []
 const removehandler_callbacks = []
 
-function observe(obs::AbstractObservable)
-    error("observe not defined for AbstractObservable $(typeof(obs))")
-end
-
 """
     obs = Observable(val; ignore_equal_values=false)
     obs = Observable{T}(val; ignore_equal_values=false)
@@ -62,7 +58,14 @@ Observable(val::T; ignore_equal_values::Bool=false) where {T} = Observable{T}(va
 
 Base.eltype(::AbstractObservable{T}) where {T} = T
 
+function observe(obs::AbstractObservable)
+    error("observe not defined for AbstractObservable $(typeof(obs))")
+end
 observe(x::Observable) = x
+Base.getindex(obs::AbstractObservable) = getindex(observe(obs))
+Base.setindex!(obs::AbstractObservable, val) = setindex!(observe(obs), val)
+listeners(obs::AbstractObservable) = listeners(observe(obs))
+obsid(obs::AbstractObservable) = obsid(observe(obs))
 
 function register_callback(@nospecialize(observable), priority::Int, @nospecialize(f))
     ls = observable.listeners::Vector{Pair{Int, Any}}

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -97,6 +97,8 @@ end
 
 Base.convert(::Type{T}, x::T) where {T<:Observable} = x  # resolves ambiguity with convert(::Type{T}, x::T) in base/essentials.jl
 Base.convert(::Type{T}, x) where {T<:Observable} = T(x)
+Core.convert(::Type{Observable{Any}}, x::Observable{Any}) = x
+precompile(Core.convert, (Type{Observable{Any}}, Observable{Any}))
 
 struct Consume
     x::Bool

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -218,12 +218,8 @@ current value is 5
 """
 function on(@nospecialize(f), @nospecialize(observable::AbstractObservable); weak::Bool = false, priority = 0, update = false)
     ls = listeners(observable)
-    idx = searchsortedfirst(ls, priority; by=first, rev=true)
-    if isnothing(idx)
-        push!(ls, priority => f)
-    else
-        insert!(ls, idx, priority => f)
-    end
+    idx = searchsortedlast(ls, priority; by=first, rev=true)
+    insert!(ls, idx + 1, priority => f)
     for g in addhandler_callbacks
         g(f, observable)
     end

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -227,7 +227,7 @@ julia> obs[] = 5;
 current value is 5
 ```
 """
-function on(@nospecialize(f), @nospecialize(observable::AbstractObservable); weak::Bool = false, priority = 0)
+function on(@nospecialize(f), @nospecialize(observable::AbstractObservable); weak::Bool = false, priority = 0, update=false)
     ls = listeners(observable)
     if observable.use_priority
         idx = findfirst(((prio, x),)-> prio < priority, ls)
@@ -241,6 +241,9 @@ function on(@nospecialize(f), @nospecialize(observable::AbstractObservable); wea
     end
     for g in addhandler_callbacks
         g(f, observable)
+    end
+    if update
+        f(observable[])
     end
     # Return a ObserverFunction so that the caller is responsible
     # to keep a reference to it around as long as they want the connection to

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,6 +61,18 @@ end
         x[] = [2,3]
         @test y[] == 1
     end
+    @testset "map" begin
+        x = Observable(0)
+        obs = map(identity, x; change_observable=true)
+        y = Observable(0)
+        on(obs) do x
+            y[] += 1
+        end
+        x[] = 0
+        @test y[] == 0
+        x[] = 1
+        @test y[] == 1
+    end
 end
 
 @testset "ambiguities" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,23 +10,23 @@ using Test
     @test y[] == 1
 end
 
-@testset "PriorityObservable" begin
-    po = PriorityObservable(0)
+@testset "Observable with Priority" begin
+    po = Observable(0)
 
     first = Observable(UInt64(0))
     second = Observable(UInt64(0))
     third = Observable(UInt64(0))
 
-    on(po, priority=1) do x
+    on(po, priority=2) do x
         sleep(0)
         first[] = time_ns()
     end
-    on(po, priority=0) do x
+    on(po, priority=1) do x
         sleep(0)
         second[] = time_ns()
         return Consume(isodd(x))
     end
-    on(po, priority=-1) do x
+    on(po, priority=0) do x
         sleep(0)
         third[] = time_ns()
         return Consume(false)
@@ -40,6 +40,9 @@ end
     x = setindex!(po, 2)
     @test x == false
     @test first[] < second[] < third[]
+
+    on(identity, po) # one more callback with priority=0
+    @test [1, 0, 0, -1] == Base.first.(po.listeners)
 end
 
 @testset "ChangeObservable" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,16 +17,16 @@ end
     second = Observable(UInt64(0))
     third = Observable(UInt64(0))
 
-    on(po, priority=2) do x
+    on(po, priority=1) do x
         sleep(0)
         first[] = time_ns()
     end
-    on(po, priority=1) do x
+    on(po, priority=0) do x
         sleep(0)
         second[] = time_ns()
         return Consume(isodd(x))
     end
-    on(po, priority=0) do x
+    on(po, priority=-1) do x
         sleep(0)
         third[] = time_ns()
         return Consume(false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,15 @@
 using Observables
 using Test
 
+@testset "on(f; update=true)" begin
+    obs = Observable(0)
+    y = Observable(0)
+    on(obs; update=true) do x
+        y[] += 1
+    end
+    @test y[] == 1
+end
+
 @testset "PriorityObservable" begin
     po = PriorityObservable(0)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,6 +45,44 @@ end
     @test [1, 0, 0, -1] == Base.first.(po.listeners)
 end
 
+
+@testset "order with/without priority" begin
+    x = Observable(1)
+
+    on(1, x)
+    on(2, x)
+    on(3, x)
+    on(4, x)
+
+    @test last.(x.listeners) == [1, 2, 3, 4]
+
+
+    x = Observable(1)
+
+    on(1, x, priority=1)
+    on(2, x, priority=2)
+    on(3, x, priority=3)
+    on(4, x, priority=4)
+
+    @test last.(x.listeners) == [4, 3, 2, 1]
+    @test first.(x.listeners) == [4, 3, 2, 1]
+
+
+    x = Observable(1)
+
+    on(1, x, priority=1)
+    on(-1, x, priority=1)
+    on(2, x, priority=2)
+    on(-2, x, priority=2)
+    on(3, x, priority=3)
+    on(-3, x, priority=3)
+    on(4, x, priority=4)
+    on(-4, x, priority=4)
+
+    @test last.(x.listeners) == [4, -4, 3, -3, 2, -2, 1, -1]
+    @test first.(x.listeners) == [4, 4, 3, 3, 2, 2, 1, 1]
+end
+
 @testset "ChangeObservable" begin
     @testset "immutable" begin
         x = ChangeObservable(0)


### PR DESCRIPTION
- add `ignore_equal_values` to Observable constructor, which implements https://github.com/JuliaGizmos/Observables.jl/pull/79 without adding a new type
- add `PriorityObservable` from Makie without adding a new type (from [PriorityObservable.jl](https://github.com/JuliaPlots/Makie.jl/blob/master/src/interaction/PriorityObservable.jl)). One can now simply add `on(f, priority::Int=...)`, to register a callback with priority.
- add `on(f, obs; update=true)`, to call `f(obs[])` immediately.
- improve compile times quite a bit

Based on `sd/compile-time` not for the best reasons, besides it being a bit easier