### PR TITLE
Custom display for ObserverFunction

### DIFF
--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -139,6 +139,25 @@ mutable struct ObserverFunction <: Function
     end
 end
 
+function Base.show(io::IO, obsf::ObserverFunction)
+    showdflt(io, @nospecialize(f), obs) = print(io, "ObserverFunction `", f, "` operating on ", obs)
+
+    nm = string(nameof(obsf.f))
+    if !occursin('#', nm)
+        showdflt(io, obsf.f, obsf.observable)
+    else
+        mths = methods(obsf.f)
+        if length(mths) == 1
+            m = only(mths)
+            print(io, "ObserverFunction defined at ", m.file, ":", m.line, " operating on ", obsf.observable)
+        else
+            showdflt(io, obsf.f, obsf.observable)
+        end
+    end
+end
+Base.show(io::IO, ::MIME"text/plain", obsf::ObserverFunction) = show(io, obsf)
+Base.print(io::IO, obsf::ObserverFunction) = show(io, obsf)   # Base.print is specialized for ::Function
+
 Base.precompile(obsf::ObserverFunction) = precompile(obsf.f, (eltype(obsf.observable),))
 function Base.precompile(observable::Observable)
     tf = true

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -148,7 +148,7 @@ function Base.show(io::IO, obsf::ObserverFunction)
     else
         mths = methods(obsf.f)
         if length(mths) == 1
-            m = only(mths)
+            m = first(mths)
             print(io, "ObserverFunction defined at ", m.file, ":", m.line, " operating on ", obsf.observable)
         else
             showdflt(io, obsf.f, obsf.observable)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,10 +13,12 @@ end
 @testset "construct and show" begin
     obs = Observable(5)
     @test string(obs) == "Observable{$Int} with 0 listeners. Value:\n5"
-    on(identity, obs)
+    f = on(identity, obs)
     @test string(obs) == "Observable{$Int} with 1 listeners. Value:\n5"
-    on(x->nothing, obs)
+    @test string(f) == "ObserverFunction `identity` operating on Observable{Int64} with 1 listeners. Value:\n5"
+    f = on(x->nothing, obs); ln = @__LINE__
     @test string(obs) == "Observable{$Int} with 2 listeners. Value:\n5"
+    @test string(f) == "ObserverFunction defined at $(@__FILE__):$ln operating on Observable{Int64} with 2 listeners. Value:\n5"
     obs[] = 7
     @test string(obs) == "Observable{$Int} with 2 listeners. Value:\n7"
     obs = Observable{Any}()


### PR DESCRIPTION
This causes named functions to print by name, but anonymous ones to
print via file:line. This may make it easier to know
where each comes from.