### PR TITLE
add forwarding of methods like getindex, getproperty etc.

### DIFF
--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -87,11 +87,11 @@ Base.getindex(observable::Observable) = observable.val
 
 # pass indexing and property methods to referenced variable
 # at least one index
-function Base.getindex(obs::AbstractObservable, arg1, args...)
+function Base.getindex(@nospecialize(obs::AbstractObservable), arg1, args...)
     getindex(getfield(observe(obs), :val), arg1, args...)
 end
 
-function Base.setindex!(obs::AbstractObservable, val, arg1, args...)
+function Base.setindex!(@nospecialize(obs::AbstractObservable), val, arg1, args...)
     setindex!(getfield(observe(obs), :val), val, arg1, args...)
     Observables.notify(obs)
 end

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -52,14 +52,6 @@ Gets a unique id for an observable.
 obsid(observable::Observable) = string(objectid(observable))
 obsid(obs::AbstractObservable) = obsid(observe(obs))
 
-function Base.getproperty(obs::Observable, field::Symbol)
-    if field === :id
-        return obsid(obs)
-    else
-        getfield(obs, field)
-    end
-end
-
 Observable(val::T; ignore_equal_values::Bool=false) where {T} = Observable{T}(val; ignore_equal_values)
 
 Base.eltype(::AbstractObservable{T}) where {T} = T
@@ -82,7 +74,7 @@ function Base.setindex!(@nospecialize(observable::Observable), @nospecialize(val
     if observable.ignore_equal_values
         isequal(observable.val, val) && return
     end
-    observable.val = val
+    setfield!(observable, :val, val)
     return notify(observable)
 end
 
@@ -92,6 +84,49 @@ end
 Returns the current value of `observable`.
 """
 Base.getindex(observable::Observable) = observable.val
+
+# pass indexing and property methods to referenced variable
+# at least one index
+function Base.getindex(obs::AbstractObservable, arg1, args...)
+    getindex(getfield(observe(obs), :val), arg1, args...)
+end
+
+function Base.setindex!(obs::AbstractObservable, val, arg1, args...)
+    setindex!(getfield(observe(obs), :val), val, arg1, args...)
+    Observables.notify(obs)
+end
+
+# update without triggering listeners: obs[!] = val
+Base.setindex!(@nospecialize(obs::AbstractObservable), @nospecialize(val), ::typeof(!)) = setfield!(observe(obs), :val, val)
+Base.getindex(@nospecialize(obs::AbstractObservable), ::typeof(!)) = getfield(observe(obs), :val)
+
+function Base.getproperty(obs::T, field::Symbol) where T <: AbstractObservable
+    if field === :id
+        return obsid(obs)
+    elseif field in fieldnames(T)
+        getfield(obs, field)
+    else
+        getproperty(getfield(observe(obs), :val), field)
+    end
+end
+
+function Base.setproperty!(@nospecialize(obs::T), field::Symbol, @nospecialize(val)) where T <: AbstractObservable
+    if field in fieldnames(T)
+        setfield!(obs, field, val)
+    else
+        setproperty!(getfield(observe(obs), :val), field, val)
+    end
+    Observables.notify(obs)
+end
+
+for f in (:push!, :pushfirst!, :pop!, :popfirst!)
+    Core.eval(@__MODULE__, """
+    function  $f(obs::AbstractObservable{T}, val) where T
+        $f(getfield(observe(obs), :val), val)
+        Observables.notify(obs)
+    end
+  """ |> Meta.parse)
+end
 
 ### Utilities
 

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -121,9 +121,10 @@ end
 
 for f in (:push!, :pushfirst!, :pop!, :popfirst!)
     Core.eval(@__MODULE__, """
-    function  $f(obs::AbstractObservable{T}, val) where T
+    function Base.$f(@nospecialize(obs::AbstractObservable), @nospecialize(val))
         $f(getfield(observe(obs), :val), val)
-        Observables.notify(obs)
+        notify(obs)
+        getfield(observe(obs), :val)
     end
   """ |> Meta.parse)
 end


### PR DESCRIPTION
This is a PR to the discussion on silent assignment #77.

@SimonDanisch 
I'm not sure whether I placed all `@nospecialize` in the right places as I'm not an expert on inference (trying to get into it ...)
E.g. line 103, I did not place @nospecialize to make the lookup of `:field in fieldnames(T)` faster. Is that notion correct? Moreover, compilation of that code should be fast and there won't be very many types around, so not too big a waste in terms of dispatch tables?
