### PR TITLE
Reintroduce setexcludinghandlers!

### DIFF
--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -86,6 +86,9 @@ function Base.setindex!(@nospecialize(observable::Observable), @nospecialize(val
     return notify(observable)
 end
 
+# For external packages that don't want to access an internal field
+setexcludinghandlers!(obs::AbstractObservable, val) = observe(obs).val = val
+
 """
     observable[]
 


### PR DESCRIPTION
`setexcludinghandlers!` was removed in https://github.com/JuliaGizmos/Observables.jl/pull/84/files#diff-717dd66a485f4523942145feb17dfcebc7bf9e137ee03fa29c1ef8c8c3b1cad6L272 but it's unclear how to update code that uses `setexcludinghandlers!`.

This pull request just puts the old code back, since e.g. `WebIO` still relies on `setexcludinghandlers!`.