### PR TITLE
Synchronized updates

### DIFF
--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -34,9 +34,16 @@ struct Consume
 end
 Consume() = Consume(true)
 
+if VERSION >= v"1.8.0"
 mutable struct Callback
     const f::Any
     state::CallbackState
+end
+else
+    mutable struct Callback
+        f::Any
+        state::CallbackState
+    end
 end
 Callback(f::Any) = Callback(f, UPTODATE)
 (cb::Callback)(val) = Base.invokelatest(cb.f, val)

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -260,6 +260,7 @@ block. It also avoids executing the same listener multiple times if multiple
 enclosed observables trigger it.
 
 The code generated from the above example is
+
     begin
         prepare_update!(obs1, val1)
         prepare_update!(obs2, val1)

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -35,10 +35,10 @@ end
 Consume() = Consume(true)
 
 if VERSION >= v"1.8.0"
-mutable struct Callback
-    const f::Any
-    state::CallbackState
-end
+    mutable struct Callback
+        const f::Any
+        state::CallbackState
+    end
 else
     mutable struct Callback
         f::Any
@@ -273,19 +273,12 @@ macro combine_updates(block::Expr)
         error("Expression should be a begin ... end block.")
     end
     
-    println("---| Initial")
-    dump(block)
     _replace_observable_update!.(block.args, (observables,))
     
-    println("\n---| Replaced")
-    println("---| ", observables)
-    dump(block)
     for name in unique(observables)
         push!(block.args, :(Observables.execute_update!($name)))
     end
     
-    println("---| Finalized")
-    dump(block)
     return esc(block)
 end
 


### PR DESCRIPTION
This is an attempt at a more formal solution to problems such as

```julia
input1 = Observable([1, 2])
input2 = Observable([1, 2])
output = Observable([(1, 1)])
f = onany(input1, input2) do a, b
    output[] = tuple.(a, b)
    return  
end

input1[] = [1, 2, 3]
input2[] = [1, 2, 3]
```

triggering a DimensionMismatch error due to `input1` executing first. The current solution to this is to write to the Observable directly with `input1.val = [1, 2, 3]` first, and then trigger an update with the second observable as usual.

While that works it requires you to modify a field of the observable which isn't great in my opinion. In a more complex network of observables you may also need to trigger both observables to run everything you need, which will double up on updates attached to both.

This pr is adding a different way to handle this:
```julia
@combine_update begin
    input1[] = [1, 2, 3, 4]
    input2[] = [1, 2, 3, 4]
end
```
which lowers to
```julia
begin
    prepare_update!(input1, [1, 2, 3, 4])
    prepare_update!(input2, [1, 2, 3, 4])
    execute_update!(input1)
    execute_update!(input2)
end
```
This will update `observable.val` and mark listeners as out-of-date via `prepare_update!` and then update them through `execute_update!`. The latter will skip over listeners that have already been executed and exit when it hits a consuming listener (consuming now or before). So it is effectively the same as
```julia
input1.val = [1, 2, 3, 4]
input2.val = [1, 2, 3, 4]
notify(input1)
notify(input2)
```
except that it skips duplicate execution of listeners.

TODO:
- [x] 1.6 compat (const in struct)