### PR TITLE
Add priority to map

### DIFF
--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -509,7 +509,7 @@ Observable{Number}(1.7320508075688772)
 
 can handle any number type for which `sqrt` is defined.
 """
-@inline function Base.map!(@nospecialize(f), result::AbstractObservable, os...; update::Bool=true, priority = 0)
+@inline function Base.map!(@nospecialize(f), result::AbstractObservable, os...; update::Bool=true, priority::Int = 0)
     # note: the @inline prevents de-specialization due to the splatting
     callback = MapCallback(f, result, os)
     # appendinputs!(result, obsfuncs)
@@ -559,7 +559,7 @@ julia> map(length, obs)
 Observable(3)
 ```
 """
-@inline function Base.map(f::F, arg1::AbstractObservable, args...; ignore_equal_values=false, priority = 0) where F
+@inline function Base.map(f::F, arg1::AbstractObservable, args...; ignore_equal_values::Bool=false, priority::Int = 0) where F
     # note: the @inline prevents de-specialization due to the splatting
     obs = Observable(f(arg1[], map(to_value, args)...); ignore_equal_values=ignore_equal_values)
     map!(f, obs, arg1, args...; update=false, priority = priority)

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -452,7 +452,7 @@ function clear(@nospecialize(obs::Observable))
 end
 
 """
-    onany(f, args...)
+    onany(f, args...; weak::Bool = false, priority::Int = 0, update::Bool = false)
 
 Calls `f` on updates to any observable refs in `args`.
 `args` may contain any number of `Observable` objects.
@@ -466,10 +466,11 @@ function onany(f, args...; weak::Bool = false, priority::Int = 0, update::Bool =
     obsfuncs = ObserverFunction[]
     for observable in args
         if observable isa AbstractObservable
-            obsfunc = on(callback, observable; weak=weak, priority=priority, update=update)
+            obsfunc = on(callback, observable; weak=weak, priority=priority)
             push!(obsfuncs, obsfunc)
         end
     end
+    update && callback(nothing)
     return obsfuncs
 end
 

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -509,12 +509,12 @@ Observable{Number}(1.7320508075688772)
 
 can handle any number type for which `sqrt` is defined.
 """
-@inline function Base.map!(@nospecialize(f), result::AbstractObservable, os...; update::Bool=true)
+@inline function Base.map!(@nospecialize(f), result::AbstractObservable, os...; update::Bool=true, priority = 0)
     # note: the @inline prevents de-specialization due to the splatting
     callback = MapCallback(f, result, os)
     # appendinputs!(result, obsfuncs)
     for o in os
-        o isa AbstractObservable && on(callback, o)
+        o isa AbstractObservable && on(callback, o, priority = priority)
     end
     update && callback(nothing)
     return result
@@ -559,10 +559,10 @@ julia> map(length, obs)
 Observable(3)
 ```
 """
-@inline function Base.map(f::F, arg1::AbstractObservable, args...; ignore_equal_values=false) where F
+@inline function Base.map(f::F, arg1::AbstractObservable, args...; ignore_equal_values=false, priority = 0) where F
     # note: the @inline prevents de-specialization due to the splatting
     obs = Observable(f(arg1[], map(to_value, args)...); ignore_equal_values=ignore_equal_values)
-    map!(f, obs, arg1, args...; update=false)
+    map!(f, obs, arg1, args...; update=false, priority = priority)
     return obs
 end
 

--- a/src/Observables.jl
+++ b/src/Observables.jl
@@ -461,12 +461,12 @@ All other objects in `args` are passed as-is.
 
 See also: [`on`](@ref).
 """
-function onany(f, args...; weak::Bool = false, priority::Int=0)
+function onany(f, args...; weak::Bool = false, priority::Int = 0, update::Bool = false)
     callback = OnAny(f, args)
     obsfuncs = ObserverFunction[]
     for observable in args
         if observable isa AbstractObservable
-            obsfunc = on(callback, observable; weak=weak, priority=priority)
+            obsfunc = on(callback, observable; weak=weak, priority=priority, update=update)
             push!(obsfuncs, obsfunc)
         end
     end


### PR DESCRIPTION
This adds the `priority` keyword to `map`.

I think I made these changes alongside https://github.com/MakieOrg/Makie.jl/pull/3084 but forgot to open a pr.  Without them `lift` and `map` are inconsistent between the `map(f, scene/plot, obs...)` and `map(f, obs...)` versions, as one supports priority and the other does not.
Will fix map/priority related errors in https://github.com/MakieOrg/Makie.jl/pull/3246.

@SimonDanisch Would be good to have this merged before the next Makie release