### PR TITLE
Allow users to specify the output eltype of `map`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Observables"
 uuid = "510215fc-4207-5dde-b226-833fc4488ee2"
-version = "0.5.5"
+version = "0.5.6"
 
 [compat]
 julia = "1.6"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -149,13 +149,14 @@ end
     obs = Observable(5)
     @test string(obs) == "Observable(5)"
     f = on(identity, obs)
-    @test occursin("Observable(5)\n    0 => identity(x) in Base at operators.jl", plain(obs))
+    @test occursin("Observable(5)\n    0 => identity(x)", plain(obs))
     @test string(f) == "ObserverFunction `identity` operating on Observable(5)"
     f = on(x->nothing, obs); ln = @__LINE__
     str = plain(obs)
     @test occursin("Observable(5)", str)
-    @test occursin("0 => identity(x) in Base at operators.jl", str)
-    @test occursin(" in Main at $(@__FILE__)", str)
+    @test occursin("0 => identity(x)", str)
+    @test occursin(" Main", str)
+    @test occursin("runtests.jl", str)
 
     @test string(f) == "ObserverFunction defined at $(@__FILE__):$ln operating on Observable(5)"
     obs[] = 7
@@ -216,6 +217,23 @@ end
     r1[] = 4
     @test r3[] === 5.0f0
 
+
+    r4 = Observable{Any}(true)
+    r5 = map(r4; out_type=:infer) do x
+        x + 1
+    end
+    @test r5[] == 2
+    r4[] = (1.5 + im)
+    @test r5[] == 2.5 + im 
+
+    r6 = Observable{Any}(true)
+    r7 = map(r6; out_type=Number) do x
+        x + 1
+    end
+    @test r7[] == 2
+    r6[] = (1.5 + im)
+    @test r7[] == 2.5 + im 
+    
     # Make sure `precompile` doesn't error
     precompile(r1)
 end


### PR DESCRIPTION
The way `map` currently works is that when you map over an Observable, the `eltype` of the new `Observable` is determined by the first application of the mapping function, i.e.
```julia-repl
julia> using Observables

julia> o1 = Observable{Any}(true);

julia> o2 = map(o1) do x
           @info "Updating o2 from o1" x
           x + 1
       end
┌ Info: Updating o2 from o1
└   x = true
Observable(2)

julia> eltype(o2) # This is bad!
Int64

julia> o1[] = 1.5 # because of this
┌ Info: Updating o2 from o1
└   x = 1.5
ERROR: InexactError: Int64(2.5)
Stacktrace:
  [1] Int64
    @ ./float.jl:994 [inlined]
  [2] convert(::Type{Int64}, x::Float64)
    @ Base ./number.jl:7
  [3] setproperty!(x::Observable{Int64}, f::Symbol, v::Float64)
    @ Base ./Base.jl:52
[...]
```
This PR keeps the current default behaviour, but adds a kwarg with two new options `out_type = :infer`
```julia-repl
julia> o2 = map(o1; out_type=:infer) do x
           @info "Updating o2 from o1" x
           x + 1
       end
┌ Info: Updating o2 from o1
└   x = true
Observable{Any}(2)


julia> o1[] = 1.5
┌ Info: Updating o2 from o1
└   x = 1.5
1.5

julia> o2[]
2.5
```
and `out_type::Type`:
```julia-repl
julia> o3 = map(o2; out_type=Number) do x
           x
       end
Observable{Number}(2.5)
```